### PR TITLE
Add an SDK-specific grunt build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,7 +86,7 @@ module.exports = function (grunt) {
         files: [
           { expand: true, cwd: '.', src: ['app/audio/**'], dest: 'build/' },
           { expand: true, cwd: '.', src: ['app/font/**'], dest: 'build/' },
-          { expand: true, cwd: '.', src: ['README.txt'], dest: 'build/app/' },
+          { expand: true, cwd: '.', src: ['README.txt'], dest: 'build/app/' }
         ]
       },
       wgt: {
@@ -102,6 +102,30 @@ module.exports = function (grunt) {
           { expand: true, cwd: 'app/_locales', src: ['**'], dest: 'build/crx/_locales' },
           { expand: true, cwd: '.', src: ['manifest.json'], dest: 'build/crx/' },
           { expand: true, cwd: '.', src: ['memory-match-icon*.png'], dest: 'build/crx/' }
+        ]
+      },
+      sdk: {
+        files: [
+          { expand: true, cwd: 'build/app/', src: ['**'], dest: 'build/sdk/' },
+          { expand: true, cwd: 'app', src: ['js/**'], dest: 'build/sdk/' },
+          { expand: true, cwd: 'app', src: ['css/**'], dest: 'build/sdk/' },
+          { expand: true, cwd: 'app', src: ['*.html'], dest: 'build/sdk/' },
+          {
+            src: 'app/lib/appframework/jq.mobi.js',
+            dest: 'build/sdk/lib/appframework/jq.mobi.js'
+          },
+          {
+            src: 'app/lib/requirejs/require.js',
+            dest: 'build/sdk/lib/requirejs/require.js'
+          },
+          {
+            src: 'app/lib/requirejs-domready/domReady.js',
+            dest: 'build/sdk/lib/requirejs-domready/domReady.js'
+          },
+          { expand: true, cwd: '.', src: ['config.xml'], dest: 'build/sdk/' },
+          { expand: true, cwd: '.', src: ['memory-match-icon.png'], dest: 'build/sdk/' },
+          { expand: true, cwd: '.', src: ['LICENSE'], dest: 'build/sdk/' },
+          { expand: true, cwd: '.', src: ['OFL.txt'], dest: 'build/sdk/' }
         ]
       }
     },
@@ -149,6 +173,15 @@ module.exports = function (grunt) {
         version: '<%= packageInfo.version %>',
         files: 'build/wgt/**',
         stripPrefix: 'build/wgt/',
+        outDir: 'build',
+        suffix: '.wgt',
+        addGitCommitId: false
+      },
+      sdk: {
+        appName: '<%= packageInfo.name %>',
+        version: '<%= packageInfo.version %>',
+        files: 'build/sdk/**',
+        stripPrefix: 'build/sdk/',
         outDir: 'build',
         suffix: '.wgt',
         addGitCommitId: false
@@ -223,19 +256,18 @@ module.exports = function (grunt) {
     'condense'
   ]);
 
+  grunt.registerTask('sdk', [
+    'clean',
+    'copy:common',
+    'imagemin:dist',
+    'copy:sdk',
+    'package:sdk'
+  ]);
+
   grunt.registerTask('wgt', ['dist', 'copy:wgt', 'package:wgt']);
   grunt.registerTask('crx', ['dist', 'copy:crx']);
 
   grunt.registerTask('install', [
-    'wgt',
-    'sdb:prepare',
-    'sdb:pushwgt',
-    'sdb:install',
-    'sdb:start'
-  ]);
-
-  grunt.registerTask('reinstall', [
-    'wgt',
     'sdb:prepare',
     'sdb:pushwgt',
     'sdb:stop',
@@ -243,6 +275,9 @@ module.exports = function (grunt) {
     'sdb:install',
     'sdb:start'
   ]);
+
+  grunt.registerTask('wgt-install', ['wgt', 'install']);
+  grunt.registerTask('sdk-install', ['sdk', 'install']);
 
   grunt.registerTask('restart', ['sdb:stop', 'sdb:start']);
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -3,100 +3,134 @@
 To run the build, you'll need to install some node modules.
 Run the following in the top-level directory of the project:
 
-  npm install
+    npm install
 
-Rather annoyingly, grunt now requires that you install
-grunt-cli globally to be able to use grunt from the
-command line. Note that the build will still use the
-version of grunt associated with this application
-(in node_modules/).
+grunt now requires that you install grunt-cli globally
+to be able to use grunt from the command line. To install
+grunt-cli do:
 
-To install grunt-cli do:
-
-  npm install -g grunt-cli
+    npm install -g grunt-cli
 
 You also need bower to install the client-side dependencies:
 
-  npm install -g bower
+    npm install -g bower
 
-You should then install the client-side dependencies into app/lib:
+Then install the client-side dependencies into app/lib:
 
-  bower install
+    bower install
+
+Note that if you want to install the application to a Tizen device
+as a wgt file, you will also need to install the sdb tool first.
+This is available for various platforms from
+http://download.tizen.org/tools/latest-release/.
+
+Configure your package manager to use the appropriate repo from the
+ones available and install sdb, e.g. for Fedora 17:
+
+    $ REPO=http://download.tizen.org/tools/latest-release/Fedora_17/tools.repo
+    $ sudo yum-config-manager --add-repo $REPO
+    $ sudo yum install sdb
 
 # WHERE'S THE APP?
 
-Open app/index.html in a browser (there's no requirement to run
-a build before you can run the app).
+There are a few options for running the application:
 
-Or you could also serve the app from a standard web server by running
+*   Open app/index.html in a browser (there's no requirement to
+    run a build before you can run the app).
 
-  grunt dist
+*   Serve the app from a standard web server. First, run:
 
-then copying the content of the build/app/ directory to a web folder.
+        grunt dist
 
-Alternatively, run:
+    Then copy the content of the build/app/ directory to a web folder
+    for your server (e.g. an Apache htdocs directory).
 
-  grunt server
+*   Run the app using the built-in local server:
 
-to build the deployment version of the app and run it on a server,
-accessible via http://localhost:30303/. This is useful for testing the
-app in a mobile device's browser.
+        grunt server
 
-Or you can install to an attached Tizen device via sdb by running:
+    This builds the dist version of the app and runs it on a server
+    accessible at http://localhost:30303/. This is useful for testing the
+    app in a mobile device: just navigate to the server hosting
+    the app, using the phone's browser.
 
-  grunt install
+*   Install/reinstall to an attached Tizen device via sdb by running:
 
-then
+        grunt wgt-install
 
-  grunt reinstall
+    This installs an optimised version of the app (minified HTML,
+    minified and concatenated CSS and JS).
 
-to reinstall the package after you've been working on the code.
+*   Install an SDK-specific version of the app (no minification or
+    concatenation) with:
 
-Or you can build the files required for a crx deployment with:
+        grunt sdk-install
 
-  grunt crx
+*   Build the files for the Chrome extension with:
 
-(NB you will have to load this as an unpacked extension in Chrome
-developer mode, as the grunt build doesn't make .crx files.)
+        grunt crx
+
+    then load the build/crx directory as an unpacked extension in Chrome
+    developer mode. (The build can't currently make full .crx packages.)
+
+*   On Linux, use make to install the app to /usr/share/. If you are
+    using the Chromium browser, you can use the Makefile as is; if not, edit the
+    Makefile so the BROWSER= variable is set to the name of your Chrome
+    binary (e.g. google-chrome instead of chromium-browser).
+
+    Then do
+
+        sudo make install
+
+    to install the application. On Linux desktops which support the
+    freedesktop.org specs, this will add the application to the standard
+    application launcher.
 
 # PACKAGING
 
 The application can be packaged into a wgt (zip) file using the grunt
 command:
 
-  ./grunt wgt
+    grunt wgt
 
 This will generate a package in the build/ directory.
+
+It can also be packaged into an SDK wgt file (with uncompressed JS,
+CSS, and HTML) using:
+
+    grunt sdk
+
+Note that in both cases, the files comprising the packages are
+first copied into the build/wgt and build/sdk directories respectively.
 
 # REQUIRE AND ALMOND
 
 During development, require is used to load modules. This makes
 debugging easier, as you have the uncompressed JS files to look at.
 
-For deployment, the r.js tool is used to minify all of the JS (from
-app/js and app/lib) into a single file (./build/dist/all.js), along
-with a minimal AMD loader (Almond). All of the other files required
-for distribution (including an index.html file modified to load the
-single JS file) are copied to ./build/dist/ if you run the dist task.
-
-See grunt.js for more details of how this works.
+For the optimised deployment targets (*not* the sdk targets),
+the grunt requirejs task minifies all of the JS (from
+app/js and app/lib) into a single file (./build/app.min.js), along
+with a minimal AMD loader (Almond). grunt also rewrites the index.html
+file so it will load this concatenated and minified single file,
+rather than the full requirejs file (see the grunt-condense task).
 
 # CACHING AND HOW TO BYPASS IT
 
 To use the app in no-cache mode (so the browser doesn't cache
 any JS files), open:
 
-  index.html?nocache
+    index.html?nocache
 
 This stops requirejs using cached copies of js files so you get
 the most recent js each time you refresh the browser.
 
 To use in normal (caching) mode, open:
 
-  index.html
+    index.html
 
 NB no-cache mode cannot be used if the app is running from a build
-(i.e. code generated and put into build/dist/, which is what the
+(i.e. code generated and put into build/app/, which is what the
 simple_server task serves).
 
 The code which looks for this URL argument is in the require configuration
@@ -110,24 +144,24 @@ defining a new module app/js/newmodule.js, which depends on
 the module in app/js/mymodule.js. To load the dependency in
 app/js/newmodule.js, you'd do this:
 
-  // NB 'mymodule' is the path to app/js/mymodule.js, relative to app/js
-  define(['mymodule'], function (MyModule) {
-    var newmodule = {
-      /*
-         DEFINE NewModule HERE;
-         in your definition of newmodule, you can make use
-         of the MyModule dependency
-      */
-    };
+    // NB 'mymodule' is the path to app/js/mymodule.js, relative to app/js
+    define(['mymodule'], function (MyModule) {
+      var newmodule = {
+        /*
+           DEFINE NewModule HERE;
+           in your definition of newmodule, you can make use
+           of the MyModule dependency
+        */
+      };
 
-    return NewModule;
-  });
+      return NewModule;
+    });
 
 # ADDING THIRD PARTY LIBRARIES
 
 Install the dependency (if possible) using bower:
 
-  bower install ...package... --save
+    bower install ...package... --save
 
 This will put the package into app/lib and save the dependency into
 the component.json file.

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Memory Match
 
 Author/Owner: Todd Brandt <todd.e.brandt@intel.com>
 
-Technical Details: This application is written using HTML5/css3/jquery javascript
+Technical Details: This application is written using HTML5/css3/jqMobi javascript
 library and is distributed under Apache2.0 license.
 
 IMAGES

--- a/app/js/gamesound.js
+++ b/app/js/gamesound.js
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2012, Intel Corporation.
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 define(function () {
   // done(GameSound) is a callback invoked with the created GameSound object
   // when the corresponding Audio object it wraps is playable

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2012, Intel Corporation.
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 require(
 ['sounds', 'help', 'license', 'ui', 'pages'],
 function (Sounds, help_init, license_init, ui_init, pagesLoader) {

--- a/app/js/pages.js
+++ b/app/js/pages.js
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2012, Intel Corporation.
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 define(['jqmobi'], function ($) {
   var init = function (doneCb) {
     $.ajax({

--- a/app/js/require-config.js
+++ b/app/js/require-config.js
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2012, Intel Corporation.
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 require.config({
   baseUrl: './js',
 

--- a/app/js/sounds.js
+++ b/app/js/sounds.js
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2012, Intel Corporation.
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 define(['gamesound'], function (GameSound) {
   var Sounds = {};
 

--- a/app/js/ui.js
+++ b/app/js/ui.js
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2012, Intel Corporation.
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
 // links the Game object to the UI and directly
 // sets up event handlers on the DOM
 define(['game', 'jqmobi', 'domReady!'], function (Game, $) {

--- a/app/js/ui.js
+++ b/app/js/ui.js
@@ -80,7 +80,7 @@ define(['game', 'jqmobi', 'domReady!'], function (Game, $) {
       $("#win_dlg_page").hide();
       $(".card").removeClass('flip');
       window.setTimeout(function () {
-        Game.start_game(Game.win_level - 1);
+        Game.start_game(Game.win_level);
       }, Game.fliptime);
     });
 

--- a/tools/grunt-tasks/grunt-sdb.js
+++ b/tools/grunt-tasks/grunt-sdb.js
@@ -140,7 +140,7 @@ module.exports = function (grunt) {
     });
   };
 
-  var getId = function (configXml, cb) {
+  var getMeta = function (configXml, cb) {
     var file = grunt.file.expand(configXml)[0];
 
     if (file) {
@@ -150,8 +150,9 @@ module.exports = function (grunt) {
             cb(err);
           }
           else {
-            var id = result.widget.$.id;
-            cb(null, id);
+            var uri = result.widget.$.id;
+            var id = result.widget['tizen:application'][0].$.id;
+            cb(null, {uri: uri, id: id});
           }
         });
       });
@@ -322,8 +323,11 @@ module.exports = function (grunt) {
     var configXml = config.config;
     var sdbCmd = config.sdbCmd;
     var remoteScript = config.remoteScript;
+    var stopOnFailure = (config.stopOnFailure === true ? true : false);
 
-    getId(configXml, function (err, id) {
+    getMeta(configXml, function (err, meta) {
+      var id = meta.uri;
+
       var cmd = sdbCmd + ' shell "' + remoteScript +
                 ' uninstall ' + id + '"';
 
@@ -332,14 +336,59 @@ module.exports = function (grunt) {
       exec(cmd, function (err, stdout, stderr) {
         grunt.log.write(stdout);
 
-        if (err || stdout.match('not installed|failed')) {
-          done(new Error('package with id ' + id + ' could not be uninstalled'));
+        var error = err || stdout.match('not installed|failed');
+
+        if (error) {
+          if (stopOnFailure) {
+            done(new Error('package with id ' + id + ' could not be uninstalled'));
+          }
+          else {
+            grunt.log.warn('could not uninstall package; continuing anyway');
+            done();
+          }
         }
         else {
           grunt.log.ok('package with id ' + id + ' uninstalled');
           done();
         }
       });
+    });
+  };
+
+  /**
+   * Run arbitrary script on the device
+   *
+   * config.remoteScript: full path to remote script
+   * NB the remote script is passed the following arguments:
+   *   $1 == the URI of the widget (widget.id from config.xml)
+   *   $2 == the ID of the widget (tizen:application.id from config.xml)
+   */
+  var script = function (config, done) {
+    var remoteScript = config.remoteScript;
+    var sdbCmd = config.sdbCmd;
+    var configXml = config.config;
+
+    getMeta(configXml, function (err, meta) {
+      var cmd = sdbCmd + ' shell "' + remoteScript + ' ' +
+                meta.uri + ' ' + meta.id + '"';
+      console.log(cmd);
+
+      if (err) {
+        done(err);
+      }
+      else {
+        exec(cmd, function (err, stdout, stderr) {
+          grunt.log.write(stdout);
+
+          if (err) {
+            grunt.log.error(err);
+            done(new Error('error occurred while running script ' + remoteScript));
+          }
+          else {
+            done();
+          }
+        });
+      }
     });
   };
 
@@ -394,7 +443,9 @@ module.exports = function (grunt) {
 
     var actionDone = (subcommand === 'stop' ? 'stopped' : 'launched');
 
-    getId(configXml, function (err, id) {
+    getMeta(configXml, function (err, meta) {
+      var id = meta.uri;
+
       var cmd = sdbCmd + ' shell "' + remoteScript +
                 ' ' + subcommand + ' ' + id + '"';
 
@@ -509,6 +560,9 @@ module.exports = function (grunt) {
     }
     else if (action === 'uninstall') {
       uninstall(this.data, done);
+    }
+    else if (action === 'script') {
+      script(this.data, done);
     }
     // stop, start, debug
     else {


### PR DESCRIPTION
Add grunt targets to make and install an SDK-tailored version of the app:
- grunt sdk does an SDK build, copying the required files to build/sdk and creating a wgt package (unsigned) from those files. The build/sdk directory can be used as example code in an SDK environment, as it contains no redundant Chrome-specific files (like manifest.json and _locales), no files irrelevant to SDK users (like HACKING.md), no build infrastructure (no bower or npm configuration), and no minified files (other than the images).
- grunt sdk-install will run the sdk task (see above) then deploy the SDK version of the app as a wgt package to an attached device (requires sdb).

Note that the package produced by the sdk target will not perform as well as a package produced with the wgt target, but the apps in both packages are otherwise equivalent.

Note that I also fixed a bug I spotted while testing the SDK build. I didn't take the time to produce a separate PR for it, but could if necessary.

And corrected an error in the README.
